### PR TITLE
Fix: Add workflows permission to GitHub Actions

### DIFF
--- a/.github/workflows/rebase-upstream.yml
+++ b/.github/workflows/rebase-upstream.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   issues: write
+  workflows: write
 
 jobs:
   rebase:

--- a/.github/workflows/release-patched-version.yml
+++ b/.github/workflows/release-patched-version.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  workflows: write
 
 jobs:
   create-patched-release:


### PR DESCRIPTION
## Problem

The release workflow failed with the error:
```
refusing to allow a GitHub App to create or update workflow 
`.github/workflows/buildkit.yml` without `workflows` permission
```

This happens when cherry-picking patches that modify workflow files.

## Solution

Add `workflows: write` permission to both:
- **release-patched-version.yml**: Needed when cherry-picking patches that include workflow changes
- **rebase-upstream.yml**: Also needs this permission when rebasing includes workflow modifications

## Testing

After this fix, the release workflow should be able to:
1. Cherry-pick patches that modify workflow files
2. Push branches containing workflow changes
3. Complete the release process successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Grants `workflows: write` permission in release and rebase GitHub Actions to allow updates when workflow files change.
> 
> - **CI/CD Permissions**:
>   - Add `workflows: write` to:
>     - `.github/workflows/release-patched-version.yml`
>     - `.github/workflows/rebase-upstream.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee7b171b0c045cc9560a66e6b55aabf763045e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->