### PR TITLE
Fix: Properly handle workflow file modifications in releases

### DIFF
--- a/.github/workflows/rebase-upstream.yml
+++ b/.github/workflows/rebase-upstream.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: write
   issues: write
-  workflows: write
 
 jobs:
   rebase:
@@ -19,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup git
         run: |

--- a/.github/workflows/release-patched-version.yml
+++ b/.github/workflows/release-patched-version.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: write
-  workflows: write
 
 jobs:
   create-patched-release:
@@ -29,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup git
         run: |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,6 +4,16 @@
 
 This fork maintains patches on top of upstream BuildKit using a rebase workflow. Our `master` branch contains upstream BuildKit plus our custom patches rebased on top.
 
+## Setup Requirements
+
+If your patches modify workflow files (`.github/workflows/*.yml`), you need to create a Personal Access Token:
+
+1. Go to GitHub Settings > Developer settings > Personal access tokens
+2. Create a new token with `repo` and `workflow` scopes
+3. Add it as a secret named `WORKFLOW_TOKEN` in your repository settings
+
+Without this token, the workflows will fall back to using `GITHUB_TOKEN`, which cannot push workflow changes.
+
 ## Creating a Patched Release
 
 To deploy a patched version of BuildKit:


### PR DESCRIPTION
## Problem

The previous fix incorrectly added `workflows: write` permission, which doesn't exist in GitHub Actions. The actual issue is that the default `GITHUB_TOKEN` cannot push changes to workflow files for security reasons.

## Root Cause

When cherry-picking patches that modify workflow files, GitHub prevents the default token from pushing these changes with the error:
```
refusing to allow a GitHub App to create or update workflow 
without 'workflows' permission
```

## Solution

1. **Remove invalid permission**: Removed the non-existent `workflows: write` permission
2. **Use Personal Access Token**: Modified both workflows to use `WORKFLOW_TOKEN` (if configured) or fall back to `GITHUB_TOKEN`
3. **Add documentation**: Added setup instructions in DEPLOYMENT.md

## Setup Required

To handle patches that modify workflows:
1. Create a Personal Access Token with `repo` and `workflow` scopes
2. Add it as `WORKFLOW_TOKEN` secret in repository settings
3. The workflows will automatically use it when available

If no PAT is configured, the workflows will use `GITHUB_TOKEN` and work normally for patches that don't modify workflows.

## Testing

- Without `WORKFLOW_TOKEN`: Works for regular patches
- With `WORKFLOW_TOKEN`: Can cherry-pick and push patches that modify workflow files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch workflows to use WORKFLOW_TOKEN (falling back to GITHUB_TOKEN) and remove the invalid workflows: write permission; add PAT setup instructions to DEPLOYMENT.md.
> 
> - **Workflows**:
>   - `/.github/workflows/rebase-upstream.yml`, `/.github/workflows/release-patched-version.yml`:
>     - Use `secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN` for checkout `token`.
>     - Remove invalid `workflows: write` permission.
> - **Docs**:
>   - `DEPLOYMENT.md`: Add Personal Access Token setup requirements and notes for handling workflow file changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6f05775734f0ce676a4dbea795e1140f1d7ad75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->