### PR TITLE
Fix: Remove broken token fallback in checkout action

### DIFF
--- a/.github/workflows/rebase-upstream.yml
+++ b/.github/workflows/rebase-upstream.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Setup git
         run: |

--- a/.github/workflows/release-patched-version.yml
+++ b/.github/workflows/release-patched-version.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Setup git
         run: |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,13 +6,23 @@ This fork maintains patches on top of upstream BuildKit using a rebase workflow.
 
 ## Setup Requirements
 
-If your patches modify workflow files (`.github/workflows/*.yml`), you need to create a Personal Access Token:
+**Required**: You must create a Personal Access Token for the workflows to function properly:
 
-1. Go to GitHub Settings > Developer settings > Personal access tokens
-2. Create a new token with `repo` and `workflow` scopes
-3. Add it as a secret named `WORKFLOW_TOKEN` in your repository settings
+1. Go to GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
+2. Click "Generate new token (classic)"
+3. Give it a descriptive name (e.g., "BuildKit Fork Workflow")
+4. Select these scopes:
+   - `repo` (all checkboxes under repo)
+   - `workflow` (update GitHub Action workflows)
+5. Generate the token and copy it
+6. Go to your fork's Settings > Secrets and variables > Actions
+7. Click "New repository secret"
+8. Name: `WORKFLOW_TOKEN`
+9. Value: Paste your Personal Access Token
 
-Without this token, the workflows will fall back to using `GITHUB_TOKEN`, which cannot push workflow changes.
+This token is necessary because:
+- The default `GITHUB_TOKEN` cannot push changes to workflow files
+- Some patches may include modifications to `.github/workflows/*.yml` files
 
 ## Creating a Patched Release
 


### PR DESCRIPTION
## Problem

The checkout action was failing with authentication errors even when `WORKFLOW_TOKEN` was configured. The `||` operator for fallback wasn't working correctly in the token field.

## Root Cause

The expression `${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}` was not being evaluated properly by the checkout action, causing authentication failures.

## Solution

1. **Simplify token usage**: Use only `${{ secrets.WORKFLOW_TOKEN }}` without fallback
2. **Update documentation**: Make it clear that setting up the PAT is required, not optional
3. **Detailed instructions**: Added step-by-step guide for creating the token with correct scopes

## Required Setup

Before using these workflows, you MUST:
1. Create a Personal Access Token with `repo` and `workflow` scopes
2. Add it as `WORKFLOW_TOKEN` secret in your repository settings

This is required because the default GITHUB_TOKEN cannot push changes to workflow files, which is needed when cherry-picking patches that modify workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use only `secrets.WORKFLOW_TOKEN` for checkout in workflows and update docs to require a PAT with setup steps.
> 
> - **Workflows**:
>   - `/.github/workflows/rebase-upstream.yml`, `/.github/workflows/release-patched-version.yml`:
>     - Set checkout `token` to `secrets.WORKFLOW_TOKEN` (remove `GITHUB_TOKEN` fallback).
> - **Docs**:
>   - `DEPLOYMENT.md`:
>     - Mark PAT as required and add step-by-step creation with `repo` and `workflow` scopes, plus rationale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5e70b980f0ebfd0986676c3c6e21541d3e353d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->