### PR TITLE
Fix: Resolve branch/tag name collision in release workflow

### DIFF
--- a/.github/workflows/create-patched-release.yml
+++ b/.github/workflows/create-patched-release.yml
@@ -67,9 +67,10 @@ jobs:
             exit 1
           fi
 
-          # Checkout upstream version
+          # Checkout upstream version with a temp branch name to avoid conflicts
           echo "Creating release branch from $VERSION..."
-          git checkout -b "$RELEASE_BRANCH" "$VERSION"
+          TEMP_BRANCH="temp-${RELEASE_BRANCH}-$$"
+          git checkout -b "$TEMP_BRANCH" "$VERSION"
 
           # Find all commits that are in origin/master but not in upstream/master
           echo ""
@@ -150,10 +151,10 @@ jobs:
           TAG_MSG=$(printf "Release %s with %s patches\n\nPatches applied:\n%s" "$VERSION" "$SUCCESS_COUNT" "$APPLIED_PATCHES")
           git tag -a "$RELEASE_TAG" -m "$TAG_MSG"
 
-          # Push the tag directly - this will trigger buildkit.yml
+          # Push the tag explicitly using refs/tags/ to avoid ambiguity
           echo ""
           echo "Pushing release tag..."
-          if git push origin "$RELEASE_TAG"; then
+          if git push origin "refs/tags/$RELEASE_TAG"; then
             echo "✅ Successfully pushed tag: $RELEASE_TAG"
             echo ""
             echo "========================================="
@@ -181,10 +182,11 @@ jobs:
             echo "To push manually:"
             echo "  git clone https://github.com/${{ github.repository }}.git"
             echo "  cd buildkit"
-            echo "  git fetch origin $RELEASE_BRANCH:$RELEASE_BRANCH"
-            echo "  git checkout $RELEASE_BRANCH"
-            echo "  git tag -a $RELEASE_TAG -m \"$TAG_MSG\""
-            echo "  git push origin $RELEASE_TAG"
+            echo "  git fetch --all --tags"
+            echo "  # Delete any conflicting branch"
+            echo "  git push origin --delete $RELEASE_TAG 2>/dev/null || true"
+            echo "  # Push the tag explicitly"
+            echo "  git push origin refs/tags/$RELEASE_TAG"
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

The release workflow failed with:
```
error: src refspec v0.26.1-blacksmith matches more than one
```

This happened because the workflow created both:
- A branch named `v0.26.1-blacksmith`
- A tag with the same name `v0.26.1-blacksmith`

When pushing, Git couldn't determine which one to push.

## Solution

1. **Use temporary branch name** during processing (`temp-${name}-$$`)
   - Avoids collision with the tag name
   
2. **Push tag explicitly** with `refs/tags/` prefix
   - Removes ambiguity about what's being pushed

3. **Update manual instructions** to handle existing conflicts

## Testing

After this fix, the workflow will:
- Process patches on a temporary branch
- Create the tag without name conflicts  
- Push the tag successfully

## For the existing v0.26.1-blacksmith release

Run these commands to complete it:
```bash
git clone https://github.com/useblacksmith/buildkit.git
cd buildkit
git fetch --all --tags

# Delete any conflicting branch
git push origin --delete v0.26.1-blacksmith 2>/dev/null || true

# Push the tag
git push origin refs/tags/v0.26.1-blacksmith
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a temporary branch when creating releases and push tags via refs/tags to prevent branch/tag ambiguity; update manual push instructions accordingly.
> 
> - **Workflow** (`.github/workflows/create-patched-release.yml`):
>   - Use a temporary branch (`temp-...-$$`) when checking out the upstream tag to avoid branch/tag name collisions.
>   - Push release tags explicitly using `refs/tags/$RELEASE_TAG` to remove ambiguity.
>   - Revise manual recovery instructions: fetch all tags, delete conflicting branch, and push the tag via `refs/tags/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3be6ea04ae1443a573c7526a1ea133d85a8299a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->