### PR TITLE
boltutil: sync bbolt databases on close to prevent corruption

### DIFF
--- a/util/db/boltutil/db.go
+++ b/util/db/boltutil/db.go
@@ -2,15 +2,40 @@ package boltutil
 
 import (
 	"io/fs"
+	"sync"
 
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/db"
 	bolt "go.etcd.io/bbolt"
 )
+
+// syncingDB wraps a bolt.DB to ensure data is synced to disk before closing.
+// This is important when using NoSync mode, as otherwise dirty pages may not
+// be flushed to disk before unmount, leading to corruption on network block
+// devices or when taking filesystem snapshots.
+type syncingDB struct {
+	*bolt.DB
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Close syncs the database to disk before closing.
+// This ensures all pending writes are flushed even when NoSync is enabled,
+// preventing corruption during graceful shutdown. Safe to call multiple times.
+func (s *syncingDB) Close() error {
+	s.closeOnce.Do(func() {
+		if err := s.Sync(); err != nil {
+			bklog.L.Warnf("failed to sync database before close: %v", err)
+		}
+		s.closeErr = s.DB.Close()
+	})
+	return s.closeErr
+}
 
 func Open(p string, mode fs.FileMode, options *bolt.Options) (db.DB, error) {
 	bdb, err := bolt.Open(p, mode, options)
 	if err != nil {
 		return nil, err
 	}
-	return bdb, nil
+	return &syncingDB{DB: bdb}, nil
 }


### PR DESCRIPTION
## Summary

- Wraps `bolt.DB` with `syncingDB` that calls `Sync()` before `Close()`
- Ensures all pending writes are flushed to disk during graceful shutdown
- Preserves `NoSync: true` performance benefits during normal operation

## Problem

When bbolt is opened with `NoSync: true`, transactions complete in memory without fsync to disk. On graceful shutdown, dirty pages in the OS page cache may not be flushed before `Close()` returns, leading to corruption when:

1. BuildKit stops gracefully (SIGTERM)
2. `Close()` returns without syncing dirty pages  
3. Filesystem unmount forces writeback of partial/torn pages
4. Snapshot captures inconsistent B-tree state

This is particularly problematic with network block devices (Ceph RBD) and container snapshot workflows.

## Solution

The fix is minimal and targeted: wrap the returned `bolt.DB` in a type that syncs before closing. This gives us the best of both worlds:
- Fast writes during operation (NoSync behavior)
- Safe state on shutdown (explicit Sync before Close)

## Test plan

- [ ] Build passes (`go build ./cmd/buildkitd/...`)
- [ ] Deploy to staging and verify graceful shutdown doesn't corrupt databases
- [ ] Monitor sticky disk corruption metrics after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps `bolt.DB` with a `syncingDB` that syncs to disk before close and updates `Open` to return it.
> 
> - **DB (`util/db/boltutil`)**:
>   - Add `syncingDB` wrapper around `bolt.DB` that calls `Sync()` before `Close()` (idempotent via `sync.Once`) and logs a warning on sync failure.
>   - Update `Open` to return `syncingDB` instead of raw `bolt.DB`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55d37dc7025c4ea174b619643502ce4764e1631b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->