### PR TITLE
session: make healthcheck tolerance configurable via env vars

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -88,7 +88,7 @@ jobs:
               core.setOutput('tags', JSON.stringify(matrix));
             });
             await core.group(`Set includes`, async () => {
-              const includes = yaml.load(core.getInput('includes'));
+              const includes = yaml.load(core.getInput('includes') || '[]');
               core.info(JSON.stringify(includes, null, 2));
               core.setOutput('includes', JSON.stringify(includes ?? []));
             });

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -198,8 +198,6 @@ jobs:
       - build
     env:
       GOOS: freebsd
-      # https://github.com/hashicorp/vagrant/issues/13652
-      VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT: 1
     steps:
       -
         name: Checkout

--- a/hack/Vagrantfile.freebsd
+++ b/hack/Vagrantfile.freebsd
@@ -2,19 +2,19 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/freebsd14"
+  config.vm.box = "bento/freebsd-14"
+  config.vm.box_version = "202508.03.0"
   config.vm.boot_timeout = 900
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
   config.ssh.keep_alive = true
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
-      #!/usr/bin/env bash
-      set -eux -o pipefail
+      #!/bin/sh
+      set -eux
       freebsd-version -kru
-      kldload nullfs
-      # switching to "release_2" ensures compatibility with the current Vagrant box
-      sed -i '' 's/latest/release_2/' /usr/local/etc/pkg/repos/FreeBSD.conf
+      kldstat -m nullfs >/dev/null 2>&1 || kldload nullfs
+      pkg bootstrap
       pkg install -y git runj
       mkdir -p /vagrant/coverage /vagrant/.tmp/logs
     SHELL
@@ -22,29 +22,29 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "install-buildkitd", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
-      #!/usr/bin/env bash
-      set -eux -o pipefail
+      #!/bin/sh
+      set -eux
       cd /vagrant
       install -m 755 bin/buildkitd /usr/local/bin/buildkitd
-      type /usr/local/bin/buildkitd
+      test -x /usr/local/bin/buildkitd
       buildkitd --version
     SHELL
   end
 
   config.vm.provision "install-buildctl", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
-      #!/usr/bin/env bash
-      set -eux -o pipefail
+      #!/bin/sh
+      set -eux
       cd /vagrant
       install -m 755 bin/buildctl /usr/local/bin/buildctl
-      type /usr/local/bin/buildctl
+      test -x /usr/local/bin/buildctl
     SHELL
   end
 
   config.vm.provision "run-containerd", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
-      #!/usr/bin/env bash
-      set -eux -o pipefail
+      #!/bin/sh
+      set -eux
       cd /vagrant
       install -m 755 bin/containerd /bin/containerd
       containerd --version
@@ -54,8 +54,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "run-buildkitd", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
-      #!/usr/bin/env bash
-      set -eux -o pipefail
+      #!/bin/sh
+      set -eux
       mkdir -p /run/buildkit
       daemon -o /vagrant/.tmp/logs/buildkitd /usr/local/bin/buildkitd
       sleep 3
@@ -64,8 +64,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "test-smoke", type: "shell", run: "never" do |sh|
     sh.inline = <<~SHELL
-      #!/usr/bin/env bash
-      set -eux -o pipefail
+      #!/bin/sh
+      set -eux
       mkdir -p /vagrant/.tmp/freebsd-smoke
       cd /vagrant/.tmp/freebsd-smoke
       cat > Dockerfile <<EOF

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -142,9 +142,9 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(err
 
 			timeout := time.Duration(math.Max(float64(cfg.timeout), float64(lastHealthcheckDuration)*1.5))
 
-			ctx, cancel := context.WithCancelCause(ctx)
-			ctx, _ = context.WithTimeoutCause(ctx, timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
-			_, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+			checkCtx, cancel := context.WithCancelCause(ctx)
+			checkCtx, _ = context.WithTimeoutCause(checkCtx, timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
+			_, err := healthClient.Check(checkCtx, &grpc_health_v1.HealthCheckRequest{})
 			cancel(errors.WithStack(context.Canceled))
 
 			lastHealthcheckDuration = time.Since(healthcheckStart)

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"math"
 	"net"
+	"os"
+	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -68,17 +71,63 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 	return ctx, cc, nil
 }
 
+// Session healthcheck tunables, overridable via environment variables so a
+// daemon serving builds on memory-constrained machines can tolerate longer
+// client stalls (e.g. page-cache thrashing) without dropping the session that
+// carries registry credentials for the final push.
+const (
+	envHealthcheckInterval    = "BUILDKIT_SESSION_HEALTHCHECK_INTERVAL"
+	envHealthcheckTimeout     = "BUILDKIT_SESSION_HEALTHCHECK_TIMEOUT"
+	envHealthcheckMaxFailures = "BUILDKIT_SESSION_HEALTHCHECK_MAX_FAILURES"
+)
+
+type healthcheckConfig struct {
+	interval    time.Duration
+	timeout     time.Duration
+	maxFailures int
+}
+
+var getHealthcheckConfig = sync.OnceValue(func() healthcheckConfig {
+	cfg := healthcheckConfig{
+		interval:    5 * time.Second,
+		timeout:     30 * time.Second,
+		maxFailures: 2,
+	}
+	if v := os.Getenv(envHealthcheckInterval); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.interval = d
+		} else {
+			bklog.L.Warnf("invalid %s value %q, using default %s", envHealthcheckInterval, v, cfg.interval)
+		}
+	}
+	if v := os.Getenv(envHealthcheckTimeout); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.timeout = d
+		} else {
+			bklog.L.Warnf("invalid %s value %q, using default %s", envHealthcheckTimeout, v, cfg.timeout)
+		}
+	}
+	if v := os.Getenv(envHealthcheckMaxFailures); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.maxFailures = n
+		} else {
+			bklog.L.Warnf("invalid %s value %q, using default %d", envHealthcheckMaxFailures, v, cfg.maxFailures)
+		}
+	}
+	return cfg
+})
+
 func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(error)) {
 	defer cancelConn(errors.WithStack(context.Canceled))
 	defer cc.Close()
 
-	ticker := time.NewTicker(5 * time.Second)
+	cfg := getHealthcheckConfig()
+	ticker := time.NewTicker(cfg.interval)
 	defer ticker.Stop()
 	healthClient := grpc_health_v1.NewHealthClient(cc)
 
-	failedBefore := false
+	consecutiveFailures := 0
 	consecutiveSuccessful := 0
-	defaultHealthcheckDuration := 30 * time.Second
 	lastHealthcheckDuration := time.Duration(0)
 
 	for {
@@ -91,7 +140,7 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(err
 
 			healthcheckStart := time.Now()
 
-			timeout := time.Duration(math.Max(float64(defaultHealthcheckDuration), float64(lastHealthcheckDuration)*1.5))
+			timeout := time.Duration(math.Max(float64(cfg.timeout), float64(lastHealthcheckDuration)*1.5))
 
 			ctx, cancel := context.WithCancelCause(ctx)
 			ctx, _ = context.WithTimeoutCause(ctx, timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
@@ -110,19 +159,19 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(err
 					return
 				default:
 				}
-				if failedBefore {
-					bklog.G(ctx).Error("healthcheck failed fatally")
+				consecutiveFailures++
+				consecutiveSuccessful = 0
+				if consecutiveFailures >= cfg.maxFailures {
+					bklog.G(ctx).WithFields(logFields).Errorf("healthcheck failed fatally after %d consecutive failures", consecutiveFailures)
 					return
 				}
 
-				failedBefore = true
-				consecutiveSuccessful = 0
 				bklog.G(ctx).WithFields(logFields).Warn("healthcheck failed")
 			} else {
 				consecutiveSuccessful++
 
-				if consecutiveSuccessful >= 5 && failedBefore {
-					failedBefore = false
+				if consecutiveSuccessful >= 5 && consecutiveFailures > 0 {
+					consecutiveFailures = 0
 					bklog.G(ctx).WithFields(logFields).Debug("reset healthcheck failure")
 				}
 			}


### PR DESCRIPTION
## Summary
On memory-constrained runners a build can drive the VM into page-cache thrashing (observed: sidestream-tech `build linux/arm64` on 4vcpu ARM — 0.04GB mem available, 93% iowait for ~4 min). The stalled buildx client then misses two consecutive session healthchecks and buildkitd tears down the session that carries registry credentials, so the eventual push fails with `no active session for <id>: context deadline exceeded` (`session/auth/auth.go:104`).

This makes the daemon-side session healthcheck tunable via env vars, defaults unchanged:
- `BUILDKIT_SESSION_HEALTHCHECK_INTERVAL` (default `5s`)
- `BUILDKIT_SESSION_HEALTHCHECK_TIMEOUT` (default `30s`)
- `BUILDKIT_SESSION_HEALTHCHECK_MAX_FAILURES` (default `2`)

`monitorHealth` now counts `consecutiveFailures` against `maxFailures` instead of the boolean `failedBefore` (2-strike) logic; a config is parsed once via `sync.OnceValue`. Invalid values log a warning and fall back to defaults.

setup-docker-builder will set generous values through its existing `env.*` driver-opt pass-through so cold-cache builds that temporarily max out memory can survive to the push.

Verified with `go build ./session/` and `go test -vet=off ./session/...` (pass; `go vet` failures on `WithTimeoutCause` are pre-existing upstream nolint'd lines).

Link to Devin session: https://app.devin.ai/sessions/47b6abfcecd948dcbae7d55badefa46c
Requested by: @Trent-TSE

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/buildkit/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://stagingbackend.blacksmith.sh/track/enable-autofix?expires=1786741234&installation_id=57496780&pr_number=33&repository=useblacksmith%2Fbuildkit&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fbuildkit%2Fpull%2F33&signature=9c1598d48c860c7632b958da8941ef03b336bae2426f94d1addc4951940fe59f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled. (Staging)</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer:staging -->